### PR TITLE
Support big endian files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.4
+julia 0.5
 GZip
+MappedArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,8 +45,15 @@ vol = NIVolume()
 niwrite(TEMP_FILE, vol)
 niread(TEMP_FILE)
 
+# Big endian
+const BE = "$(tempname()).nii"
+download("https://nifti.nimh.nih.gov/nifti-1/data/avg152T1_LR_nifti.nii.gz", BE)
+img = niread(BE)
+@test size(img) == (91,109,91)
+
 # Clean up
 rm(NII)
 rm(HDR)
 rm(IMG)
 rm(TEMP_FILE)
+rm(BE)


### PR DESCRIPTION
@SimonDanisch and I were looking for standard test data, and I found https://nifti.nimh.nih.gov/nifti-1/data. These seemed to be the standard test data sets, so I was initially surprised that these wouldn't open. A little poking around revealed that it was an endianness issue. MappedArrays makes this trivial to support even with mmap.

From playing with it a little, I'd say the indexing needs work: I get errors from very trivial operations, like
```julia
julia> maximum(img)
ERROR: MethodError: no method matching setindex!(::UInt8, ::Float32, ::Int64)
 in getindex(::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}, ::CartesianIndex{3}) at /home/tim/.julia/v0.5/NIfTI/src/NIfTI.jl:540
 in next(::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}, ::Tuple{CartesianRange{CartesianIndex{3}},CartesianIndex{3}}) at ./abstractarray.jl:683
 in mapfoldl(::Base.#identity, ::Function, ::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}) at ./reduce.jl:62
 in _mapreduce(::Function, ::Function, ::Base.LinearSlow, ::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}) at ./reduce.jl:167
 in mapreduce(::Function, ::Function, ::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}) at ./reduce.jl:169
 in maximum(::NIfTI.NIVolume{UInt8,3,Array{UInt8,3}}) at ./reduce.jl:302
 in eval(::Module, ::Any) at ./boot.jl:234
```
I'm planning on just extracting the `raw` field manually, so it's not a big issue.