### PR TITLE
fix bug in qform to sform transformation

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -245,7 +245,7 @@ function getaffine(h::NIfTI1Header)
             pixdim[3]
             pixdim[1]*pixdim[4]
         ]
-        return vcat(hcat(A*B, [
+        return vcat(hcat(A.*B, [
             h.qoffset_x
             h.qoffset_y
             h.qoffset_z


### PR DESCRIPTION
pixdim should be multiplied rowwise, matrix multiplication leads to dimension mismatch error