### PR TITLE
write to mmapped files on disk

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -464,8 +464,8 @@ end
 """
 
 """
-function niread(file::AbstractString; mmap::Bool=false)
-    file_io = open(file, "r")
+function niread(file::AbstractString; mmap::Bool=false, mode::AbstractString="r")
+    file_io = open(file, mode)
     header_gzipped = isgz(file_io)
     header_io = header_gzipped ? gzdopen(file_io) : file_io
     header, swapped = read_header(header_io)
@@ -509,7 +509,7 @@ function niread(file::AbstractString; mmap::Bool=false)
             end
         end
 
-        volume_io = open(volume_name, "r")
+        volume_io = open(volume_name, mode)
         volume_gzipped = isgz(volume_io)
         if mmap
             if volume_gzipped

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,16 @@ vol = NIVolume()
 niwrite(TEMP_FILE, vol)
 niread(TEMP_FILE)
 
+# Open mmaped file for reading and writing
+const WRITE = "$(tempname()).nii"
+const VERIFY_WRITE = "$(tempname()).nii"
+cp(NII, WRITE)
+img = niread(WRITE; mmap=true, mode="r+")
+img.raw[1,1,1,1] = 5
+img.raw[:,2,1,1] = ones(size(img)[1])
+cp(WRITE, VERIFY_WRITE)
+@test niread(VERIFY_WRITE)[1,1,1,1] == 5
+@test niread(VERIFY_WRITE)[:,2,1,1] == ones(size(img)[1])
 # Site is currently down TODO: reintroduce this test when site is up
 # Big endian
 # const BE = "$(tempname()).nii"
@@ -55,9 +65,12 @@ niread(TEMP_FILE)
 img = niread("data/avg152T1_LR_nifti.nii.gz")
 @test size(img) == (91,109,91)
 
+GC.gc() # closes mmapped files
 # Clean up
 rm(NII)
 rm(HDR)
 rm(IMG)
 rm(TEMP_FILE)
+rm(WRITE)
+rm(VERIFY_WRITE)
 # rm(BE)


### PR DESCRIPTION
Additional optional argument for niread 'writeable'. When set to true, it is possible to write to mmapped files.
Default behaviour is unchanged

New tests for writing to mmapped files.
Garbage collection after the tests to close all inactive mmapped files, before removing them from disk.