### PR TITLE
added support for Bool datatype #38

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NIfTI"
 uuid = "f897abbf-c5d9-45cb-bf89-9f7f579a29ec"
-version = "0.1.0"
+version = "0.4.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,16 @@ vol = NIVolume()
 niwrite(TEMP_FILE, vol)
 niread(TEMP_FILE)
 
+# Write and read DT_BINARY
+const BOOL_WRITE = "$(tempname()).nii"
+const BIT_WRITE = "$(tempname()).nii"
+mask = rand(Bool, 3, 5, 7) # Array{Bool}
+mask_bitarray = BitArray(mask) # BitArray
+niwrite(BOOL_WRITE, NIVolume(mask))
+niwrite(BIT_WRITE, NIVolume(mask_bitarray))
+@test niread(BOOL_WRITE).raw == mask
+@test niread(BIT_WRITE).raw == mask_bitarray
+
 # Open mmaped file for reading and writing
 const WRITE = "$(tempname()).nii"
 const VERIFY_WRITE = "$(tempname()).nii"
@@ -73,4 +83,6 @@ rm(IMG)
 rm(TEMP_FILE)
 rm(WRITE)
 rm(VERIFY_WRITE)
+rm(BOOL_WRITE)
+rm(BIT_WRITE)
 # rm(BE)


### PR DESCRIPTION
Add support for Bool datatype #38 
Testcase for Array{Bool} and BitArray
Bump version to 0.4.1
Fix of one error message
Change of one warn() to println (warn() not supported anymore)