### PR TITLE
Fix uuid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "NIfTI"
-uuid = "f897abbf-c5d9-45cb-bf89-9f7f579a29ec"
+uuid = "a3a9e032-41b5-5fc4-967a-a6b7a19844d3"
 version = "0.4.1"
 
 [deps]


### PR DESCRIPTION
I think this problem arose during the switch from Require to Project files. NIfTI.jl was assigned a uuid in the general registry which we didn't carry over in the repo. This just copies the one from the 'General/N/NIfTI/Package.toml'